### PR TITLE
Removed clean from unit-test-app.sh

### DIFF
--- a/ci/unit-test-app.sh
+++ b/ci/unit-test-app.sh
@@ -1,2 +1,2 @@
 #! /bin/bash
-gradle clean test -p app
+gradle test -p app


### PR DESCRIPTION
Clean removes the build directory, which prevented students from completing the next task of retrieving the .jar file and building docker images in lab 06