### PR TITLE
fix(build-cache): corrects max cache size to 10GB to reflect GitHub changes

### DIFF
--- a/labs/build-cache.md
+++ b/labs/build-cache.md
@@ -31,7 +31,7 @@ To use cache at the consequtive jobs, the same code (from above example) has to 
 
 Limitations on using caching: 
 * Github will delete all unaccessed caches for 7 days.
-* There is no limit on how many caches can be stored in the repository as long as it is below 5GB. 
+* There is no limit on how many caches can be stored, however if the total space used by the repository exceeds 10GB GitHub will start deleting the oldest caches. 
 
 # Tasks 
 


### PR DESCRIPTION
Since late 2021 the size has been increased to 10GB: https://github.blog/changelog/2021-11-23-github-actions-cache-size-is-now-increased-to-10gb-per-repository/

Also slightly rewords the eviction policy to make it more clear that it's on the total volume and that it evicts FIFO. 

Full documentation:
https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy