### PR TITLE
Update storing-artifacts.md

### DIFF
--- a/labs/storing-artifacts.md
+++ b/labs/storing-artifacts.md
@@ -259,7 +259,7 @@ Your new `Test` job should look like this:
           include-hidden-files: true
 
       - name: Run unit tests
-        run: ./ci/unit-test-app.sh
+        run: ci/unit-test-app.sh
 ```
 
 Finally, let's fix the `Linting` job. Linting only needs the source code; it doesn't depend on the build at all. We can make it run in parallel to save time.


### PR DESCRIPTION
This pull request updates the `labs/storing-artifacts.md` file to introduce  an extra exercise to reorganize the workflow for better efficiency and alignment with best practices. The changes include breaking the workflow into dedicated jobs (`build`, `test`, and `lint`), optimizing artifact usage, and improving parallelism.

### Enhancements to the tutorial:

* Added an "Extra Exercise" section to guide users on reorganizing their workflows into three dedicated jobs: `build`, `test`, and `lint`. This includes separating responsibilities and improving efficiency.

### Workflow improvements:

* Updated the `Build` job to upload only the necessary build artifact instead of the entire source code.
* Added a new `Test` job that runs after the `Build` job, downloads the build artifact, and executes unit tests against it.
* Modified the `Linting` job to run in parallel by removing the dependency on the `Build` job and replacing the artifact download step with a repository checkout step.