### PR TITLE
Improve clarity and consistency in extend-pipeline.md

### DIFF
--- a/labs/extend-pipeline.md
+++ b/labs/extend-pipeline.md
@@ -1,6 +1,6 @@
 # Extending the pipeline
 
-After the application is build, the unit test should be performed to check if it works as expected.
+After the web service is built, we want to run the unit tests to check if it works as expected.
 
 This part is made as a recap of the previous exercise, to remind you how to add a step to the pipeline.
 
@@ -12,12 +12,15 @@ This part is made as a recap of the previous exercise, to remind you how to add 
 
 ### Tasks
 
-- Add a step running the unit test named `Test`,
-- The step should `run` the script `ci/unit-test-app.sh`. If you want to know what the script is doing, look into [the script](../ci/unit-test-app.sh).
+- Open the file `.github/workflows/main.yml`.
+- In the job named `Build`, after the step named `Build application`, add a new step named `Test`.
+- The step should `run` the script `ci/unit-test-app.sh`. If you want to know what the script is doing,
+  look into [the script](../ci/unit-test-app.sh).
 
 ## Solution
 
-If you struggle and need to see the whole ***Solution*** you can extend the section below.
+If you need to see the whole _*Solution*_ you can extend the section below.
+
 <details>
     <summary> Solution </summary>
   
@@ -41,7 +44,7 @@ jobs:
 
 ## Results
 
-If the exercise is completed correctly. The output of `Test` step will look like:
+If the exercise is completed correctly, the output of `Test` step will look similar to this:
 
 ``` bash
 > Task :compileJava UP-TO-DATE
@@ -63,4 +66,4 @@ BUILD SUCCESSFUL in 6s
 4 actionable tasks: 2 executed, 2 up-to-date
 ```
 
-Great, now you have a pipeline that builds and tests your application :tada:
+Great, now you have a pipeline that builds and tests your web service :tada:


### PR DESCRIPTION
This pull request updates the instructions in the `labs/extend-pipeline.md` documentation to clarify how to extend the CI pipeline for a web service. The changes improve clarity, specify file locations, and update terminology to be more accurate.

Documentation improvements:

* Updated the initial description to specify that the pipeline is for a web service and clarified the purpose of running unit tests.
* Expanded the tasks section to guide users to edit `.github/workflows/main.yml`, specify the correct job and step names, and clarify where to add the new test step.
* Improved the results section to clarify expected output and updated language for consistency and accuracy. [[1]](diffhunk://#diff-c425986e2fe6d6bc0f464e2120ea7f3714e4ab53301c98871a2e58897227731cL44-R47) [[2]](diffhunk://#diff-c425986e2fe6d6bc0f464e2120ea7f3714e4ab53301c98871a2e58897227731cL66-R69)