### PR TITLE
Fix typos and improve clarity in storing artifacts documentation

### DIFF
--- a/labs/storing-artifacts.md
+++ b/labs/storing-artifacts.md
@@ -10,19 +10,20 @@
 
 Super-linter is a tool that can be used to lint your sourcecode. It is a combination of multiple linters, and can be used to lint multiple languages.
 
-It's invoked as a github action, and can be found on [Github Marketplace](https://github.com/super-linter/super-linter).
+It's invoked as a GitHub action, and can be found on [GitHub Marketplace](https://github.com/super-linter/super-linter).
 
 In this exercise we will use it to lint our sourcecode in a separate job.
 
 ### Upload and download artifacts
 
-When running multiple jobs, the runner you get for each job is completely new.
+When running multiple jobs in a workflow, the runner you get for each job is completely new.
 
-This means that the state of the repository is not persisted between jobs.
+This means that any files created during a job, are not available in the next job, including the
+repository files.
 
-> :bulb: This should not be mistaken for proper [artifact management](https://www.eficode.com/blog/artifactory-nexus-proget), or [release management](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) but it is useful for making the artifacts built by the pipeline available.
+> :bulb: The following should not be mistaken for proper [artifact management](https://www.eficode.com/blog/artifactory-nexus-proget), or [release management](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) but it is useful for making the artifacts built by the pipeline available.
 
-To deal with artifacts, a `Github Actions Action` can be used, which can be found on [Github Marketplace](https://github.com/marketplace).
+To deal with artifacts, a `GitHub Actions Action` can be used, which can be found on [GitHub Marketplace](https://github.com/marketplace).
 
 To upload artifacts use the following syntax with `actions/upload-artifact@v4` [Link to documentation](https://github.com/marketplace/actions/upload-a-build-artifact):
 
@@ -34,7 +35,7 @@ To upload artifacts use the following syntax with `actions/upload-artifact@v4` [
     path: path/to/artifact/ # A file, directory or wildcard pattern that describes what to upload. Required.
 ```
 
-As artifacts can be uploaded it can also be downloaded from Github Actions with help of `actions/download-artifact@v4` as:
+As artifacts can be uploaded it can also be downloaded from GitHub Actions with help of `actions/download-artifact@v4` as:
 
 ```YAML
 - name: Download a single artifact # Name of the step
@@ -44,12 +45,13 @@ As artifacts can be uploaded it can also be downloaded from Github Actions with 
     path: path/to/download/artifact/     # Destination path. Supports basic tilde expansion.  # Optional. Default is $GITHUB_WORKSPACE
 ```
 
-You can find more information around the different parameters via the [link to documentation for download action](https://github.com/actions/download-artifact).
+You can find more information around the different parameters in the
+[documentation for the download-artifact action](https://github.com/actions/download-artifact).
 
 :bulb:
 <details>
     <summary> More information about storing artifacts </summary>
-  Github has an excellent guide on how you can use persistent storage over periods of builds here: https://docs.github.com/en/actions/guides/storing-workflow-data-as-artifacts
+  GitHub has an excellent guide on how you can use persistent storage over periods of builds here: https://docs.github.com/en/actions/guides/storing-workflow-data-as-artifacts
 </details>
 
 ## Exercise
@@ -99,7 +101,7 @@ jobs:
 
 </details>
 
-Push that up to your repository and check the actions tab.
+Commit and push that to your repository and check the actions tab.
 
 If all works out fine, your newest build should show something like, where you can find your uploaded artifact:
 ![Uploading artifact](img/storing-artifact.png)
@@ -111,9 +113,9 @@ We will now create a new job, which will use super-linter to lint our sourcecode
 - add a new job named `Linting` to your workflow
 - Like the other job it will run on `ubuntu-latest`
 - It `needs` the `Build` step. Add a line under `runs-on` with `needs: [Build]`
-- It will have two steps, `Download code` and `run linting`
+- It will have two steps, `Download code` and `Run linting`
   - `Download code` uses the `actions/download-artifact@v4` action to download the artifact `code` to the current directory `.`
-  - `run linting` uses the `super-linter/super-linter/slim` action to lint the code. It needs two environment variables to work:
+  - `Run linting` uses the `super-linter/super-linter/slim@v7` action to lint the code. It needs two environment variables to work:
     - `DEFAULT_BRANCH` which should be set to `main`
     - `GITHUB_TOKEN` which should be set to `${{ secrets.GITHUB_TOKEN }}`
 
@@ -182,6 +184,9 @@ It seems like we have some linting errors in our code. As this is not a python/b
 ```
 
 Push that up to your repository and see that the linting now passes, even though we have errors in our code.
+
+> :bulb: Disabling linting errors is of course not the correct solution in a real project, but for
+> this exercise it will have to do.
 
 Congratulations! You have now created a workflow with multiple jobs, and used artifacts to share data between them.
 


### PR DESCRIPTION
This pull request makes several improvements to the `labs/storing-artifacts.md` documentation, focusing on clarity, accuracy, and consistency in instructions related to using GitHub Actions for artifact management and linting. The main changes include clarifying explanations, correcting terminology, and updating action usage instructions.

**Documentation improvements and clarification:**

* Improved explanations about GitHub Actions runners, artifact persistence, and clarified the distinction between artifact management and release management.
* Reworded and reformatted references and links for better readability, including documentation links for artifact upload and download actions.
* Updated instructions to use more precise language, such as "Commit and push" instead of just "Push."

**Consistency and accuracy in GitHub Actions usage:**

* Standardized the capitalization of "GitHub" and updated references to the correct marketplace and actions, such as `super-linter/super-linter/slim@v7`. Also clarified step names and environment variable usage for the linting job. [[1]](diffhunk://#diff-5c9c273b3075e1db493c236f5a09aaa010d72f31aeeeaad43387bcff6f163ab9L37-R38) [[2]](diffhunk://#diff-5c9c273b3075e1db493c236f5a09aaa010d72f31aeeeaad43387bcff6f163ab9L114-R118)

**Exercise guidance:**

* Added a note clarifying that disabling linting errors is not recommended in real projects, but is acceptable for the purposes of this exercise.