### PR TITLE
Add start and done folders with solutions for fundamental exercises

### DIFF
--- a/labs/build-app/done/main.yml
+++ b/labs/build-app/done/main.yml
@@ -1,0 +1,11 @@
+name: Main workflow
+on: push
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    container: gradle:6-jdk11
+    steps:
+      - name: Clone down repository
+        uses: actions/checkout@v4       
+      - name: Build application
+        run: ci/build-app.sh

--- a/labs/build-app/start/main.yml
+++ b/labs/build-app/start/main.yml
@@ -1,0 +1,36 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          echo Add other actions to build,
+          echo test, and deploy your project.

--- a/labs/docker-image/done/main.yml
+++ b/labs/docker-image/done/main.yml
@@ -1,0 +1,67 @@
+name: Main workflow
+on: push
+env: # Set the secret as an input
+  github_username: ${{ github.actor }}
+  github_password: ${{ secrets.GITHUB_TOKEN }} # Must be made available to the workflow
+  GIT_COMMIT: ${{ github.sha }}
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    container: gradle:6-jdk11
+    steps:
+      - name: Clone down repository
+        uses: actions/checkout@v4       
+      - name: Build application
+        run: ci/build-app.sh
+      - name: Test
+        run: ci/unit-test-app.sh
+      - name: Upload repo
+        uses: actions/upload-artifact@v4
+        with: 
+          name: code
+          path: .
+          include-hidden-files: true
+
+  Linting:
+    runs-on: ubuntu-latest
+    needs: [Build]
+    steps:
+      - name: Download code
+        uses: actions/download-artifact@v4
+        with:
+          name: code
+          path: .
+      - name: run linting
+        uses: super-linter/super-linter/slim@v7 
+        env:
+          DEFAULT_BRANCH: main
+          # To report GitHub Actions status checks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISABLE_ERRORS: true
+
+  Docker-image:
+    runs-on: ubuntu-latest
+    needs: [Build]
+    permissions:
+      packages: write
+    steps:
+    - name: Download code
+      uses: actions/download-artifact@v4
+      with:
+        name: code
+        path: .
+    - name: Validate Docker username is all lowercase
+      id: validate_lower
+      run: |
+        if [[ "${{ env.github_username }}" =~ [A-Z] ]]; then
+          echo "::error::Validation Failed: GitHub username '${{ env.github_username }}' cannot contain uppercase characters."
+          exit 1
+        else
+          echo "Docker username format is valid."
+        fi
+      shell: bash
+    - name: build docker
+      run: bash ci/build-docker.sh
+    - name: push docker
+      run: bash ci/push-docker.sh

--- a/labs/docker-image/start/main.yml
+++ b/labs/docker-image/start/main.yml
@@ -1,0 +1,36 @@
+name: Main workflow
+on: push
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    container: gradle:6-jdk11
+    steps:
+      - name: Clone down repository
+        uses: actions/checkout@v4       
+      - name: Build application
+        run: ci/build-app.sh
+      - name: Test
+        run: ci/unit-test-app.sh
+      - name: Upload repo
+        uses: actions/upload-artifact@v4
+        with: 
+          name: code
+          path: .
+          include-hidden-files: true
+
+  Linting:
+    runs-on: ubuntu-latest
+    needs: [Build]
+    steps:
+      - name: Download code
+        uses: actions/download-artifact@v4
+        with:
+          name: code
+          path: .
+      - name: run linting
+        uses: super-linter/super-linter/slim@v7 
+        env:
+          DEFAULT_BRANCH: main
+          # To report GitHub Actions status checks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISABLE_ERRORS: true 

--- a/labs/extend-pipeline/done/main.yml
+++ b/labs/extend-pipeline/done/main.yml
@@ -1,0 +1,13 @@
+name: Main workflow
+on: push
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    container: gradle:6-jdk11
+    steps:
+      - name: Clone down repository
+        uses: actions/checkout@v4       
+      - name: Build application
+        run: ci/build-app.sh
+      - name: Test
+        run: ci/unit-test-app.sh

--- a/labs/extend-pipeline/start/main.yml
+++ b/labs/extend-pipeline/start/main.yml
@@ -1,0 +1,11 @@
+name: Main workflow
+on: push
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    container: gradle:6-jdk11
+    steps:
+      - name: Clone down repository
+        uses: actions/checkout@v4       
+      - name: Build application
+        run: ci/build-app.sh

--- a/labs/setup/done/main.yml
+++ b/labs/setup/done/main.yml
@@ -1,0 +1,36 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          echo Add other actions to build,
+          echo test, and deploy your project.

--- a/labs/storing-artifacts/done/main.yml
+++ b/labs/storing-artifacts/done/main.yml
@@ -1,0 +1,36 @@
+name: Main workflow
+on: push
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    container: gradle:6-jdk11
+    steps:
+      - name: Clone down repository
+        uses: actions/checkout@v4       
+      - name: Build application
+        run: ci/build-app.sh
+      - name: Test
+        run: ci/unit-test-app.sh
+      - name: Upload repo
+        uses: actions/upload-artifact@v4
+        with: 
+          name: code
+          path: .
+          include-hidden-files: true
+
+  Linting:
+    runs-on: ubuntu-latest
+    needs: [Build]
+    steps:
+      - name: Download code
+        uses: actions/download-artifact@v4
+        with:
+          name: code
+          path: .
+      - name: run linting
+        uses: super-linter/super-linter/slim@v7 
+        env:
+          DEFAULT_BRANCH: main
+          # To report GitHub Actions status checks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISABLE_ERRORS: true 

--- a/labs/storing-artifacts/start/main.yml
+++ b/labs/storing-artifacts/start/main.yml
@@ -1,0 +1,13 @@
+name: Main workflow
+on: push
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    container: gradle:6-jdk11
+    steps:
+      - name: Clone down repository
+        uses: actions/checkout@v4       
+      - name: Build application
+        run: ci/build-app.sh
+      - name: Test
+        run: ci/unit-test-app.sh

--- a/labs/systems-test/done/main.yml
+++ b/labs/systems-test/done/main.yml
@@ -1,0 +1,91 @@
+name: Main workflow
+on: push
+env: # Set the secret as an input
+  github_username: ${{ github.actor }}
+  github_password: ${{ secrets.GITHUB_TOKEN }} # Must be made available to the workflow
+  GIT_COMMIT: ${{ github.sha }}
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    container: gradle:6-jdk11
+    steps:
+      - name: Clone down repository
+        uses: actions/checkout@v4       
+      - name: Build application
+        run: ci/build-app.sh
+      - name: Test
+        run: ci/unit-test-app.sh
+      - name: Upload repo
+        uses: actions/upload-artifact@v4
+        with: 
+          name: code
+          path: .
+          include-hidden-files: true
+
+  Linting:
+    runs-on: ubuntu-latest
+    needs: [Build]
+    steps:
+      - name: Download code
+        uses: actions/download-artifact@v4
+        with:
+          name: code
+          path: .
+      - name: run linting
+        uses: super-linter/super-linter/slim@v7 
+        env:
+          DEFAULT_BRANCH: main
+          # To report GitHub Actions status checks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISABLE_ERRORS: true
+
+  Docker-image:
+    runs-on: ubuntu-latest
+    needs: [Build]
+    permissions:
+      packages: write
+    steps:
+    - name: Download code
+      uses: actions/download-artifact@v4
+      with:
+        name: code
+        path: .
+    - name: Validate Docker username is all lowercase
+      id: validate_lower
+      run: |
+        if [[ "${{ env.github_username }}" =~ [A-Z] ]]; then
+          echo "::error::Validation Failed: GitHub username '${{ env.github_username }}' cannot contain uppercase characters."
+          exit 1
+        else
+          echo "Docker username format is valid."
+        fi
+      shell: bash
+    - name: build docker
+      run: bash ci/build-docker.sh
+    - name: push docker
+      run: bash ci/push-docker.sh
+
+  Component-test:
+    runs-on: ubuntu-latest
+    needs: Docker-image
+    steps:
+    - name: Download code
+      uses: actions/download-artifact@v4
+      with:
+        name: code
+        path: .
+    - name: Execute component test
+      run: bash ci/component-test.sh
+
+  Performance-test:
+    runs-on: ubuntu-latest
+    needs: Docker-image
+    steps:
+    - name: Download code
+      uses: actions/download-artifact@v4
+      with:
+        name: code
+        path: .
+    - name: Execute performance test
+      run: bash ci/performance-test.sh

--- a/labs/systems-test/start/main.yml
+++ b/labs/systems-test/start/main.yml
@@ -1,0 +1,67 @@
+name: Main workflow
+on: push
+env: # Set the secret as an input
+  github_username: ${{ github.actor }}
+  github_password: ${{ secrets.GITHUB_TOKEN }} # Must be made available to the workflow
+  GIT_COMMIT: ${{ github.sha }}
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    container: gradle:6-jdk11
+    steps:
+      - name: Clone down repository
+        uses: actions/checkout@v4       
+      - name: Build application
+        run: ci/build-app.sh
+      - name: Test
+        run: ci/unit-test-app.sh
+      - name: Upload repo
+        uses: actions/upload-artifact@v4
+        with: 
+          name: code
+          path: .
+          include-hidden-files: true
+
+  Linting:
+    runs-on: ubuntu-latest
+    needs: [Build]
+    steps:
+      - name: Download code
+        uses: actions/download-artifact@v4
+        with:
+          name: code
+          path: .
+      - name: run linting
+        uses: super-linter/super-linter/slim@v7 
+        env:
+          DEFAULT_BRANCH: main
+          # To report GitHub Actions status checks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISABLE_ERRORS: true
+
+  Docker-image:
+    runs-on: ubuntu-latest
+    needs: [Build]
+    permissions:
+      packages: write
+    steps:
+    - name: Download code
+      uses: actions/download-artifact@v4
+      with:
+        name: code
+        path: .
+    - name: Validate Docker username is all lowercase
+      id: validate_lower
+      run: |
+        if [[ "${{ env.github_username }}" =~ [A-Z] ]]; then
+          echo "::error::Validation Failed: GitHub username '${{ env.github_username }}' cannot contain uppercase characters."
+          exit 1
+        else
+          echo "Docker username format is valid."
+        fi
+      shell: bash
+    - name: build docker
+      run: bash ci/build-docker.sh
+    - name: push docker
+      run: bash ci/push-docker.sh


### PR DESCRIPTION
This PR adds `start` and `done` folders to each of the funamentals-level exercises. They are not (yet) referenced anywhere, but can be used to ensure a known good state to start from, if for some reason you can't get the previous exercise to work. We're using the same pattern in the [Kubernetes katas](https://github.com/eficode-academy/kubernetes-katas/).