### PR TITLE
feat: add selfhosted runner lab

### DIFF
--- a/labs/selfhosted-runner.md
+++ b/labs/selfhosted-runner.md
@@ -14,60 +14,104 @@ We want to take parts of your pipeline and run it locally, to see if that will s
 
 ## Tasks
 
-* Setup a local runner
+You will be running a selfhosted runner on your local machine or on a VM if you have
+one available. To verify that the runner works, you will set up and run a workflow that
+matches to OS of your local machine.
 
-  * Click on Settings > Actions > General > Runners
-  * Click `"New self-hosted runner"`
-  * Choose `Linux`, leave Architecture settings for `x64`
-  * Follow the download instructions and configure instructions in a terminal where you are standing in `/home/ubuntu` (so not in the github-actions-katas folder) on your instance
+### Setup a workflow to test with
+
+The first step is to set up and test the workflow that you intend to run locally.
+There are separate, prepared workflow files available depending on the OS you
+har on your local machine.
+
+1. Copy one of the following files to your `.github/workflows` folder:
+
+   * Windows: `labs/selfhosted-runners/hello-world-windows.yml`
+   * MacOS or Linux: `labs/selfhosted-runners/hello-world-unix.yml`
+  
+   The workflows are initially set up to run on appropriate Windows or Linux runners
+   hosted by GitHub.
+
+2. Commit and push the changes, so that the workflow is available in the GitHub UI.
+3. Go the the Actions tab in the GitHub UI and run the `Hello Selfhosted Runner` workflow.
+4. Verify that the workflow has run successfully and examine the output.
+
+### Setup a local runner
+
+Now that you have a workflow to test with, you need to deploy an instance of the GitHub Runner
+application on your local machine and configure it to connect to your GitHub account.
+
+1. In the `github-actions-katas` repository on your personal GitHub account, click on Settings > Actions > Runners
+2. Click the `"New self-hosted runner"` button in the upper right-hand corner.
+3. Choose an OS and Architecture that matches your local machine
+   * On Windows and Linux, the achitecuter will likely be `x64`
+   * On MacOS, the architecture will likely be `ARM64`
+4. Follow the download instructions and configure instructions in a new terminal window.
+
+The instructions will guide you to
+
+1. create a folder for the local runner
+2. download and extract the necessary binary
+3. configure it to access your repository using a token generated as part of the instructions.
+   Press enter in each step of the configuration wizard to choose the default options.
+4. run the local runner instance
 
 You should see something like this at the end:
 
 ```bash
-[ubuntu@devopsacademy-instance1 actions-runner ]
 $  ./run.sh
 
 √ Connected to GitHub
+
+Current runner version: '2.329.0'
+2025-11-04 21:17:44Z: Listening for Jobs
 ```
 
-Now you are ready to use the runner in your pipeline.
+Now you are ready to use the runner in your workflow.
 
-___
+### Run a workflow against the local runner
 
-* Use the local runner in your pipeline
+To verify that workflows run on your local runner, we need to update the test workflow
+and run it again. We will observe that the log in your local terminal will print
+status messages from the workflow.
 
-  * in your pipeline, change the `runs-on` parameter in the component test from `ubuntu-latest` to `self-hosted`
+1. Edit the `Hello Selfhosted Runner` workflow file in `.github/workflows`
+2. Change the `runs-on` parameter in the component test from `ubuntu-latest` or
+   `windows-latest` to `self-hosted`
 
-    ```yaml
-      Component-test:
-        # runs-on: [ubuntu-latest]
-        runs-on: [self-hosted]
-    ```
+   ```yaml
+     hello-world:
+       runs-on: [self-hosted]
+   ```
 
-  * Commit and push that change and observe that the CI gets triggered.
-  * In the terminal where you are running the GH Actions runner, you should see something like this:
+3. Commit and push the change, then trigger the workflow manually.
+4. In the terminal where you are running the GitHub Actions runner, you should see something like this:
 
-      ```bash
-      2021-08-11 10:14:27Z: Listening for Jobs
-      2021-08-11 10:26:17Z: Running job: Component-test
-      2021-08-11 10:27:40Z: Job Component-test completed with result: Succeeded
-      ```
+   ```bash
+   2025-11-04 21:18:41Z: Running job: hello-world
+   2025-11-04 21:18:51Z: Job hello-world completed with result: Succeeded
+   ```
 
-  * Is there a time difference between running your pipeline with a local runner and with a Github provided runner?
+### Removing the local runner
 
-___
+Since this is just a test, and you don't want local runners available in public repositories,
+you need to remove the runner registration from GitHub and clean up the working directory
 
-* Make the local runner run as a service
+1. In the `github-actions-katas` repository on your personal GitHub account, click on Settings > Actions > Runners
+2. Click on your newly created runner to open its status page. Here you can see any
+   currently active jobs on the runner.
+3. Press the big red Remove button. The dialog that appears will show you the necessary
+   command to de-register the runner.
+4. Copy the command to remove the runner.
+5. Switch to the terminal window where the local runner is active.
+6. Press `Crtl+C` to stop the runner.
+7. Paste the `remove` command into the shell and execute it.
+   * Observe that the runner is now removed from the GitHub UI.
+8. Finally delete the folder that you created for the runner. This will clean up
+   any work files and binaries that we have downloaded.
 
-     Right now the runner is attached to a bash session in VS code. If you kill that session, the runner will be stopped.
-     So in order for us to have it running in the background, we need to run it as a service.
-
-  * In the terminal where you are running the GH Actions runner, kill the current bash session with `Ctrl+C`
-  * Follow the `Installing the service`, `Starting the service` and `Checking the status of the service` instructions on how to run the runner as a service here: <https://docs.github.com/en/actions/hosting-your-own-runners/configuring-the-self-hosted-runner-application-as-a-service>
-
-  * Rerun the last actions run, or push another commit to trigger the pipeline to see the local runner still works.
-
-Congratulations! You have now configured a local runner and used it in your pipeline!
+Congratulations! You have now configured a local runner, used it in your workflow
+and cleaned it up again!
 
 ### Resources
 

--- a/labs/selfhosted-runner/hello-world-unix.yml
+++ b/labs/selfhosted-runner/hello-world-unix.yml
@@ -1,0 +1,38 @@
+name: Hello Selfhosted Runner
+
+on:
+  workflow_dispatch:
+
+jobs:
+  hello-world:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Display environment info
+      run: |
+        echo "Hello from a self-hosted runner!"
+        echo "Current user: $(whoami)"
+        echo "Operating system: $(uname -s)"
+        echo "Hostname: $(hostname)"
+        echo "Current directory: $(pwd)"
+        echo "Shell: $SHELL"
+        
+    - name: Simple shell script test
+      run: |
+        echo "Running a simple shell script..."
+        echo "Creating a test file..."
+        echo "Hello from GitHub Actions!" > hello.txt
+        cat hello.txt
+        rm hello.txt
+        echo "Test file created and cleaned up successfully!"
+        
+    - name: Check available commands
+      run: |
+        echo "Checking if common commands are available:"
+        which git && echo "✓ Git is available" || echo "✗ Git not found"
+        which curl && echo "✓ Curl is available" || echo "✗ Curl not found"
+        which node && echo "✓ Node.js is available" || echo "✗ Node.js not found"
+        which python3 && echo "✓ Python3 is available" || echo "✗ Python3 not found"

--- a/labs/selfhosted-runner/hello-world-windows.yml
+++ b/labs/selfhosted-runner/hello-world-windows.yml
@@ -1,0 +1,41 @@
+name: Hello Selfhosted Runner
+
+on:
+  workflow_dispatch:
+
+jobs:
+  hello-world:
+    runs-on: windows-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Display environment info
+      shell: powershell
+      run: |
+        Write-Host "Hello from a self-hosted Windows runner!"
+        Write-Host "Current user: $env:USERNAME"
+        Write-Host "Computer name: $env:COMPUTERNAME"
+        Write-Host "Operating system: $((Get-CimInstance Win32_OperatingSystem).Caption)"
+        Write-Host "Current directory: $(Get-Location)"
+        Write-Host "PowerShell version: $($PSVersionTable.PSVersion)"
+        
+    - name: Simple PowerShell script test
+      shell: powershell
+      run: |
+        Write-Host "Running a simple PowerShell script..."
+        Write-Host "Creating a test file..."
+        "Hello from GitHub Actions!" | Out-File -FilePath "hello.txt"
+        Get-Content "hello.txt"
+        Remove-Item "hello.txt"
+        Write-Host "Test file created and cleaned up successfully!"
+        
+    - name: Check available commands
+      shell: powershell
+      run: |
+        Write-Host "Checking if common commands are available:"
+        try { git --version; Write-Host "✓ Git is available" } catch { Write-Host "✗ Git not found" }
+        try { curl --version; Write-Host "✓ Curl is available" } catch { Write-Host "✗ Curl not found" }
+        try { node --version; Write-Host "✓ Node.js is available" } catch { Write-Host "✗ Node.js not found" }
+        try { python --version; Write-Host "✓ Python is available" } catch { Write-Host "✗ Python not found" }


### PR DESCRIPTION
This pull request significantly improves the documentation and resources for setting up and testing a self-hosted GitHub Actions runner. The main focus is on providing clear, step-by-step instructions for running workflows locally on both Unix and Windows systems, along with ready-made workflow files for each platform. It also introduces guidance for cleaning up the runner after testing.

Key changes include:

**Documentation and Workflow Setup Improvements:**

* The `labs/selfhosted-runner.md` guide is extensively rewritten to provide detailed, step-by-step instructions for setting up, testing, and removing a self-hosted runner, including workflow preparation, runner registration, workflow execution, and cleanup procedures.

**New Example Workflow Files:**

* Added `hello-world-unix.yml`, a sample workflow for Unix-based systems that checks out code, displays environment information, runs a shell script, and verifies the availability of common tools.
* Added `hello-world-windows.yml`, a sample workflow for Windows systems that performs similar actions using PowerShell.